### PR TITLE
Document the TRX40 Aorus Master's one zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements:
 - python3
 - cython-hidapi (make sure to install "hidapi", not "hid")
 - either root access or permissions to enable regular users to send
-SET_REPORTs over HID
+`SET_REPORT`s over HID
 
 The main interface for configuring the RGB values is a USB-HID device 
 from ITE. You can find an entry via lsusb similar to this:
@@ -24,9 +24,9 @@ but you can modify that as such if your lsusb returns something different:
 
 Refer to sample.py for usage. Possible zones I've uncovered are enumerated
 in the zone_dict in aorusx570_rgb.py. I've only so far been able to confirm
-that DLED_1 (5v ARGB), LED_CX (12v RGB, there are two headers but they use the 
-same settings) and IO_LED work. I may try out the others as I get more RGB
-accessories. 
+that `D_LED1` (5v ARGB), `LED_CX` (12v RGB, there are two headers but they use
+the same settings) and `IO_LED` work. I may try out the others as I get more
+RGB accessories.
 
 Only static color changes are supported - it's up to the user to use this to 
 implement more interesting patterns in their own wrapper. 
@@ -34,3 +34,9 @@ implement more interesting patterns in their own wrapper.
 As is this is good enough for my own needs, but I'm leaving this public
 in case someone from a larger project such as OpenRGB wants to utilize
 these findings.
+
+## Aorus Master TRX40
+
+The Aorus Master TRX40 has two LED zones. The trapezoidal prism on the IO
+shield can be controlled with `IO_LED`; this is the only controllable zone
+built into the motherboard.

--- a/aorusx570_rgb.py
+++ b/aorusx570_rgb.py
@@ -27,7 +27,6 @@ class AorusRGBController:
         assert isinstance(zone,str), "Zone should be a string"
         assert zone in zone_dict, "Provided zone is not in zone_dict"
 
-
         if (r < 0 or r > 255):
             print("r is out of bounds [0-255]")
             return
@@ -54,7 +53,6 @@ class AorusRGBController:
         except:
             print("Failed to set rgb! Check USB permissions or run as root!")
 
-    
 if __name__ == "__main__":
     print("Please import this into your own application.")
     exit()


### PR DESCRIPTION
I've got an Aorus Master TRX40 here. The existing HID code works; I've added documentation specifying that the single on-board zone is `IO_LED`.